### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM fefrei/carl:17.08
+COPY / /root/hypro/
+RUN apt-get update \
+&& apt-get install -y \
+    openjdk-8-jre \
+    uuid-dev \
+    pkg-config \
+    libboost-dev
+RUN cd /root/hypro \
+&& mkdir build && cd build && cmake ../ \
+&& make resources \
+&& make


### PR DESCRIPTION
This PR adds a Dockerfile so that the HyPro repository becomes a valid source for an automated build on Docker Hub. A test repository on Docker Hub based on my PR is [here](https://hub.docker.com/r/fefrei/hypro-testing/).

Here are some things that we may want to discuss:

- This PR bases the docker container on `fefrei/carl`, a Docker container I created in my personal namespace because no official Carl Docker container appears to exist. It might make sense to create a Carl container in the yet-to-be-created HyPro namespace on Docker Hub instead.
- This puts HyPro in `/root/hypro`, just as Carl is installed in `/root/carl`. Other directories might make more sense, I'd be happy to change this.