### PR TITLE
Docker: Update to Carl 17.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fefrei/carl:17.08
+FROM fefrei/carl:17.10
 COPY / /root/hypro/
 RUN apt-get update \
 && apt-get install -y \


### PR DESCRIPTION
This updates Carl to 17.10.

I've confirmed locally that this builds, but didn't run any further tests.